### PR TITLE
[feature, #9] improved error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ const ir = require('ir-api')
 
 const { getValidPrimaryCurrencyCodes } = ir()
 
-getValidPrimaryCurrencyCodes().then(codes => {
-  console.log('codes', codes)
-})
+getValidPrimaryCurrencyCodes()
+  .then(codes => {
+    console.log('codes', codes)
+  })
+  .catch(error => {
+    console.error(error)
+  })
 ```
 
 ### Private Methods
@@ -43,9 +47,13 @@ const ir = require('ir-api')
 
 const { getOpenOrders } = ir('my-api-key', 'my-api-secret')
 
-getOpenOrders().then(data => {
-  console.log('data', data)
-})
+getOpenOrders()
+  .then(data => {
+    console.log('data', data)
+  })
+  .catch(error => {
+    console.error(error)
+  })
 ```
 
 ### Passing parameters to methods
@@ -56,9 +64,13 @@ Parameters are passed as an object, so for example
 getOpenOrders({
   primaryCurrencyCode: 'Xbt',
   secondaryCurrencyCode: 'Usd'
-}).then(data => {
-  console.log('data', data)
 })
+  .then(data => {
+    console.log('data', data)
+  })
+  .catch(error => {
+    console.error(error)
+  })
 ```
 
 ### Configuring `axios`
@@ -110,14 +122,9 @@ See [this gist](https://gist.github.com/davesag/3567876481344419827e514bae78a02b
 
 ### Errors
 
-If an API call returns an error we return it as
-
-```js
-{
-  code: 'some code', // an error code or numeric status
-  message: 'some message' // some helpful message
-}
-```
+- API request errors (in the case where the API server does not respond, such as a timeout error) are returned as a `RequestError`. You can look in `error.details` for more information about the specific error.
+- API response errors (when the API responds with an error code) are returned as a `ResponseError`. You can look in `error.status` for the status code and `error.details` for more information.
+- any other errors are simply thrown as normal javascript errors.
 
 ## Development
 

--- a/src/errors/RequestError.js
+++ b/src/errors/RequestError.js
@@ -1,0 +1,10 @@
+class RequestError extends Error {
+  constructor(message, details) {
+    super(message)
+    this.name = this.constructor.name
+    Error.captureStackTrace(this, this.constructor)
+    this.details = details
+  }
+}
+
+module.exports = RequestError

--- a/src/errors/ResponseError.js
+++ b/src/errors/ResponseError.js
@@ -1,0 +1,12 @@
+const RequestError = require('./RequestError')
+
+class ResponseError extends RequestError {
+  constructor(message, status, details) {
+    super(message, details)
+    this.name = this.constructor.name
+    Error.captureStackTrace(this, this.constructor)
+    this.status = status || 400
+  }
+}
+
+module.exports = ResponseError

--- a/src/errors/ValidationError.js
+++ b/src/errors/ValidationError.js
@@ -1,0 +1,10 @@
+class ValidationError extends Error {
+  constructor(message, fields) {
+    super(message)
+    this.name = this.constructor.name
+    Error.captureStackTrace(this, this.constructor)
+    this.fields = fields
+  }
+}
+
+module.exports = ValidationError

--- a/src/utils/transformError.js
+++ b/src/utils/transformError.js
@@ -1,6 +1,23 @@
-const transformError = error => ({
-  code: error.code || 400,
-  message: error.message || 'No error message received'
-})
+const ResponseError = require('../errors/ResponseError')
+const RequestError = require('../errors/RequestError')
+
+const transformError = error => {
+  // console.log(error)
+  const details = error.config ? { url: error.config.url } : {}
+
+  if (error.response) {
+    throw new ResponseError(
+      error.response.data['Message'],
+      error.response.status,
+      details
+    )
+  }
+
+  if (error.request) {
+    throw new RequestError(error.message, details)
+  }
+
+  throw new Error(error.message)
+}
 
 module.exports = transformError

--- a/test/unit/errors/RequestError.test.js
+++ b/test/unit/errors/RequestError.test.js
@@ -1,0 +1,29 @@
+const { expect } = require('chai')
+
+const RequestError = require('../../../src/errors/RequestError')
+
+describe('errors/RequestError', () => {
+  const message = 'a message'
+
+  context('given detail', () => {
+    const detail = 'detail'
+
+    const error = new RequestError(message, detail)
+
+    it('has the message', () => {
+      expect(error).to.have.property('message', message)
+    })
+
+    it('has the detail', () => {
+      expect(error).to.have.property('message', message)
+    })
+  })
+
+  context('no details', () => {
+    const error = new RequestError(message)
+
+    it('details are undefined', () => {
+      expect(error.details).to.be.undefined
+    })
+  })
+})

--- a/test/unit/errors/ResponseError.test.js
+++ b/test/unit/errors/ResponseError.test.js
@@ -1,0 +1,45 @@
+const { expect } = require('chai')
+
+const ResponseError = require('../../../src/errors/ResponseError')
+
+describe('errors/ResponseError', () => {
+  const message = 'a message'
+
+  context('given a status', () => {
+    const status = 404
+
+    context('given detail', () => {
+      const details = 'details'
+
+      const error = new ResponseError(message, status, details)
+
+      it('has the message', () => {
+        expect(error).to.have.property('message', message)
+      })
+
+      it('has the status', () => {
+        expect(error).to.have.property('status', status)
+      })
+
+      it('has the details', () => {
+        expect(error).to.have.property('details', details)
+      })
+    })
+
+    context('given no details', () => {
+      const error = new ResponseError(message, status)
+
+      it('details are undefined', () => {
+        expect(error.details).to.be.undefined
+      })
+    })
+  })
+
+  context('given no status', () => {
+    const error = new ResponseError(message)
+
+    it('has the default status', () => {
+      expect(error).to.have.property('status', 400)
+    })
+  })
+})

--- a/test/unit/errors/ValidationError.test.js
+++ b/test/unit/errors/ValidationError.test.js
@@ -1,0 +1,17 @@
+const { expect } = require('chai')
+
+const ValidationError = require('../../../src/errors/ValidationError')
+
+describe('errors/ValidationError', () => {
+  const message = 'a message'
+  const fields = { orderGuid: 'missing' }
+  const error = new ValidationError(message, fields)
+
+  it('has the message', () => {
+    expect(error).to.have.property('message', message)
+  })
+
+  it('has the fields', () => {
+    expect(error.fields).to.deep.equal(fields)
+  })
+})


### PR DESCRIPTION
API now throws either a `RequestError` or `ResponseError` instead of silently failing.
