### PR TITLE
[bug fix, issue #770] Remove txType validation in GetTransactions

### DIFF
--- a/src/api/private/getTransactions.js
+++ b/src/api/private/getTransactions.js
@@ -8,7 +8,6 @@ const isTime = require('../../validation/isTime')
 
 const validation = {
   accountGuid: ['isRequired', 'isGuid'],
-  txTypes: ['isRequired', isArrayOf(['Brokerage', 'Trade'])],
   pageIndex: ['isPositiveNumber'],
   pageSize: [isPositiveNumber(50)]
 }

--- a/src/api/private/getTransactions.js
+++ b/src/api/private/getTransactions.js
@@ -3,7 +3,6 @@ const { getTransport } = require('../../utils/transport')
 const { defaultParams } = require('../../defaults')
 const { validateFields } = require('../../validation')
 const isPositiveNumber = require('../../validation/isPositiveNumber')
-const isArrayOf = require('../../validation/isArrayOf')
 const isTime = require('../../validation/isTime')
 
 const validation = {


### PR DESCRIPTION
The code attempts to validate transaction types, which unnecessarily limits the module now.  Defining the allowable transaction types isn't the right way to do this either - it will just cause issues going forward.  If we remove validation, and the dev requests a txType that doesn't exist, the code fails just as before.  Adding validation in this wrapper doesn't add anything (except it does hide the actual error with a vague "Validation error" message). Removing this line fixes two issues:
1. Incorrect "isRequired" validation - txTypes is not a mandatory parameter
2. Incorrect txTypes options subset - there are many more transaction types than Brokerage and Trade.  See here: https://github.com/independentreserve/dotNetApiClient/blob/b314952ef35ca65758bd826e2b735d33ca227e1f/src/DotNetClientApi/Data/TransactionType.cs#L12