### PR TITLE
[BUG, issue #770] remove validation on txTypes for getTransactions

### DIFF
--- a/src/api/private/getTransactions.js
+++ b/src/api/private/getTransactions.js
@@ -3,12 +3,10 @@ const { getTransport } = require('../../utils/transport')
 const { defaultParams } = require('../../defaults')
 const { validateFields } = require('../../validation')
 const isPositiveNumber = require('../../validation/isPositiveNumber')
-const isArrayOf = require('../../validation/isArrayOf')
 const isTime = require('../../validation/isTime')
 
 const validation = {
   accountGuid: ['isRequired', 'isGuid'],
-  txTypes: ['isRequired', isArrayOf(['Brokerage', 'Trade'])],
   pageIndex: ['isPositiveNumber'],
   pageSize: [isPositiveNumber(50)]
 }

--- a/test/unit/api/private/getTransactions.test.js
+++ b/test/unit/api/private/getTransactions.test.js
@@ -1,6 +1,5 @@
 const doTest = require('../../../helpers/privateHandlerTest')
 const isPositiveNumber = require('../../../../src/validation/isPositiveNumber')
-const isArrayOf = require('../../../../src/validation/isArrayOf')
 const isTime = require('../../../../src/validation/isTime')
 
 const fromTimestampUtc = '2014-08-01T08:00:00Z'
@@ -19,7 +18,6 @@ const config = {
     accountGuid: ['isRequired', 'isGuid'],
     fromTimestampUtc: ['isRequired', isTime({ before: toTimestampUtc })],
     toTimestampUtc: ['isRequired', isTime({ after: fromTimestampUtc })],
-    txTypes: ['isRequired', isArrayOf(['Brokerage', 'Trade'])],
     pageIndex: ['isPositiveNumber'],
     pageSize: [isPositiveNumber(50)]
   }


### PR DESCRIPTION
The code attempts to validate transaction types, which unnecessarily limits the module now. 

Defining the allowable transaction types isn't the right way to do this either - it will just cause issues going forward. If we remove validation, and the dev requests a txType that doesn't exist, the code fails just as before. Adding validation in this wrapper doesn't add anything (except it does hide the actual error with a vague "Validation error" message). 

Removing this line fixes two issues:
1. Incorrect "isRequired" validation - txTypes is not a mandatory parameter
2. Incorrect txTypes options subset - there are many more transaction types than Brokerage and Trade. See here: https://github.com/independentreserve/dotNetApiClient/blob/b314952ef35ca65758bd826e2b735d33ca227e1f/src/DotNetClientApi/Data/TransactionType.cs#L12

https://github.com/davesag/ir-api/issues/770