### PR TITLE
[BUG, issue #773] pageSize max increase to 5000 for getTransactions

### DIFF
--- a/src/api/private/getTransactions.js
+++ b/src/api/private/getTransactions.js
@@ -10,7 +10,7 @@ const validation = {
   accountGuid: ['isRequired', 'isGuid'],
   txTypes: ['isRequired', isArrayOf(['Brokerage', 'Trade'])],
   pageIndex: ['isPositiveNumber'],
-  pageSize: [isPositiveNumber(50)]
+  pageSize: [isPositiveNumber(5000)]
 }
 
 // https://www.independentreserve.com/products/api#GetTransactions

--- a/test/unit/api/private/getTransactions.test.js
+++ b/test/unit/api/private/getTransactions.test.js
@@ -21,7 +21,7 @@ const config = {
     toTimestampUtc: ['isRequired', isTime({ after: fromTimestampUtc })],
     txTypes: ['isRequired', isArrayOf(['Brokerage', 'Trade'])],
     pageIndex: ['isPositiveNumber'],
-    pageSize: [isPositiveNumber(50)]
+    pageSize: [isPositiveNumber(5000)]
   }
 }
 


### PR DESCRIPTION
The pageSize max is now 5,000, as described here:

https://www.independentreserve.com/au/features/api#GetTransactions